### PR TITLE
Skip whitespace at the start of file

### DIFF
--- a/src/libs/util/plist.cpp
+++ b/src/libs/util/plist.cpp
@@ -40,6 +40,11 @@ bool Plist::read(const QString &fileName)
         m_hasError = true;
         return false;
     }
+    
+    char buf;
+    // Skip whitespace at the beginning of file
+    while (file->peek(&buf, 1) > 0 && isspace(buf))
+        file->read(1);
 
     QXmlStreamReader xml(file.data());
 


### PR DESCRIPTION
This is a deviation from the `XML` spec that no white space must be present before the first `xml` tag